### PR TITLE
Chromium 10.0.648.133 can't guess the encoding of brook.view.htmltemplate

### DIFF
--- a/t/brook.view.htmltemplate.html
+++ b/t/brook.view.htmltemplate.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Brook Core Test</title>
+    <meta charset="utf-8" />
     <script src="../lib/namespace.js"></script>
 <script>
     Date.now = function(){ return (new Date).getTime()};


### PR DESCRIPTION
Chromium 10.0.648.133 can't guess the encoding of brook.view.htmltemplate.unit.js. Because this script contains multibyte character.

Then I've added <meta charset="utf-8" /> to solve this problem.
