### PR TITLE
brook.util.match関数のIFを拡張しました

### DIFF
--- a/build/brook-core.js
+++ b/build/brook-core.js
@@ -246,9 +246,13 @@ Namespace('brook.util')
             },val);
         });
     };
-    var match = function(dispatchTable){
+    var match = function(dispatchTable, matcher){
         return ns.promise(function(next,val){
-            var promise = dispatchTable[val] || dispatchTable.__default__ || ns.promise();
+            var promise;
+            if(matcher)
+                promise = dispatchTable[matcher(val)];
+            if(!promise)
+                promise = dispatchTable[val] || dispatchTable.__default__ || ns.promise();
             promise.subscribe(function(v){
                 next(v);
             },val);

--- a/build/brook-mobile.js
+++ b/build/brook-mobile.js
@@ -246,9 +246,13 @@ Namespace('brook.util')
             },val);
         });
     };
-    var match = function(dispatchTable){
+    var match = function(dispatchTable, matcher){
         return ns.promise(function(next,val){
-            var promise = dispatchTable[val] || dispatchTable.__default__ || ns.promise();
+            var promise;
+            if(matcher)
+                promise = dispatchTable[matcher(val)];
+            if(!promise)
+                promise = dispatchTable[val] || dispatchTable.__default__ || ns.promise();
             promise.subscribe(function(v){
                 next(v);
             },val);

--- a/build/brook.js
+++ b/build/brook.js
@@ -246,9 +246,13 @@ Namespace('brook.util')
             },val);
         });
     };
-    var match = function(dispatchTable){
+    var match = function(dispatchTable, matcher){
         return ns.promise(function(next,val){
-            var promise = dispatchTable[val] || dispatchTable.__default__ || ns.promise();
+            var promise;
+            if(matcher)
+                promise = dispatchTable[matcher(val)];
+            if(!promise)
+                promise = dispatchTable[val] || dispatchTable.__default__ || ns.promise();
             promise.subscribe(function(v){
                 next(v);
             },val);

--- a/src/brook/util.js
+++ b/src/brook/util.js
@@ -115,9 +115,13 @@ Namespace('brook.util')
             },val);
         });
     };
-    var match = function(dispatchTable){
+    var match = function(dispatchTable, matcher){
         return ns.promise(function(next,val){
-            var promise = dispatchTable[val] || dispatchTable.__default__ || ns.promise();
+            var promise;
+            if(matcher)
+                promise = dispatchTable[matcher(val)];
+            if(!promise)
+                promise = dispatchTable[val] || dispatchTable.__default__ || ns.promise();
             promise.subscribe(function(v){
                 next(v);
             },val);

--- a/t/brook.gateway.unit.js
+++ b/t/brook.gateway.unit.js
@@ -73,7 +73,7 @@ test('cond',function(){with(ns){
 }});
 
 test('match',function(){with(ns){
-    expect(4);
+    expect(9);
     var p = promise().bind(
         match({
             10 : ns.promise(function(n,v){ equal(v,10);n(v)}),
@@ -84,6 +84,41 @@ test('match',function(){with(ns){
         })
     );
     scatter().bind(p).run([10,11,12]);
+
+    var dispatchTable = {
+        mode_should_be_foo : ns.promise(function(n,v){ equal(v.mode, 'foo'); n(v);}),
+        mode_should_be_bar : ns.promise(function(n,v){ equal(v.mode, 'bar'); }),
+        mode_should_be_baz : ns.promise(function(n,v){ equal(v.mode, 'baz'); }),
+    };
+    var before = promise(function(n,v){
+        var ret = {
+            mode : v,
+            value : 'before_value'
+        };
+        n(ret);
+    });
+    var matcher = function(v){
+        var ret;
+        switch (v.mode) {
+            case 'foo' :
+                ret = 'mode_should_be_foo';
+                break;
+            case 'bar' :
+                ret = 'mode_should_be_bar';
+                break;
+            case 'baz' :
+                ret = 'mode_should_be_baz';
+                break;
+        };
+        return ret;
+    };
+    var after = promise(function(n,v){
+        equal(v.mode, 'foo');
+        equal(v.value, 'before_value');
+    });
+    scatter().bind(
+        before.bind(match(dispatchTable, matcher), after)
+    ).run(['foo','bar','baz']);
 }});
 
 test('named channel',function(){

--- a/t/brook.unit.js
+++ b/t/brook.unit.js
@@ -118,7 +118,7 @@ test('cond',function(){with(ns){
 }});
 
 test('match',function(){with(ns){
-    expect(4);
+    expect(9);
     var p = promise().bind(
         match({
             10 : ns.promise(function(n,v){ equal(v,10);n(v)}),
@@ -129,6 +129,41 @@ test('match',function(){with(ns){
         })
     );
     scatter().bind(p).run([10,11,12]);
+
+    var dispatchTable = {
+        mode_should_be_foo : ns.promise(function(n,v){ equal(v.mode, 'foo'); n(v);}),
+        mode_should_be_bar : ns.promise(function(n,v){ equal(v.mode, 'bar'); }),
+        mode_should_be_baz : ns.promise(function(n,v){ equal(v.mode, 'baz'); }),
+    };
+    var before = promise(function(n,v){
+        var ret = {
+            mode : v,
+            value : 'before_value'
+        };
+        n(ret);
+    });
+    var matcher = function(v){
+        var ret;
+        switch (v.mode) {
+            case 'foo' :
+                ret = 'mode_should_be_foo';
+                break;
+            case 'bar' :
+                ret = 'mode_should_be_bar';
+                break;
+            case 'baz' :
+                ret = 'mode_should_be_baz';
+                break;
+        };
+        return ret;
+    };
+    var after = promise(function(n,v){
+        equal(v.mode, 'foo');
+        equal(v.value, 'before_value');
+    });
+    scatter().bind(
+        before.bind(match(dispatchTable, matcher), after)
+    ).run(['foo','bar','baz']);
 }});
 
 test('named channel',function(){


### PR DESCRIPTION
今までmatchでは最後のrun/subscribeから指定した文字列を元に実行するpromiseチェーンを決定した上で、
そのまま指定された文字列を次のpromiseに引き渡していました。

そのため、match関数をpromiseチェーンの途中に挟み込んで値を引き回すということができませんでした。

AJAXでサーバーと通信してから、その結果を引き回してその後の処理チェーンを切り替えたいというニーズは割とあるのではないのかなと思いmatch関数のIFを拡張することで実現してみました。

お手数ですが、ご査収のほど宜しくお願いいたします。
