### PR TITLE
Fixed brook.util from(undefined) causes error

### DIFF
--- a/src/brook/util.js
+++ b/src/brook/util.js
@@ -158,7 +158,7 @@ Namespace('brook.util')
         return ns.promise(tryLock);
     };
     var from = function(value){
-        if( value.observe ){
+        if( value && value.observe ){
             return ns.promise(function(next,val){
                 value.observe(ns.promise(function(n,v){
                     next(v);


### PR DESCRIPTION
brook.util from() checks value.observe even if value === undefined, which results uncaunght exception. Fixed this bug.
