### PR TITLE
brook.dom.compat#datasetの修正

### DIFF
--- a/build/brook-core.js
+++ b/build/brook-core.js
@@ -289,7 +289,7 @@ Namespace('brook.util')
         return ns.promise(tryLock);
     };
     var from = function(value){
-        if( value.observe ){
+        if( value && value.observe ){
             return ns.promise(function(next,val){
                 value.observe(ns.promise(function(n,v){
                     next(v);

--- a/build/brook-mobile.js
+++ b/build/brook-mobile.js
@@ -289,7 +289,7 @@ Namespace('brook.util')
         return ns.promise(tryLock);
     };
     var from = function(value){
-        if( value.observe ){
+        if( value && value.observe ){
             return ns.promise(function(next,val){
                 value.observe(ns.promise(function(n,v){
                     next(v);
@@ -1244,22 +1244,12 @@ Namespace('brook.view.htmltemplate')
 Namespace('brook.dom.compat')
 .define(function(ns){
     var dataset = (function(){
-        var wrapper = function(element){
-            return element.dataset;
-        };
-        if( 'HTMLElement' in window && HTMLElement.prototype ){
-            var proto = HTMLElement.prototype;
-            if( proto.dataset ) 
-                return wrapper;
-            if( proto.__lookupGetter__ && proto.__lookupGetter__('dataset') ) 
-                return wrapper;
-        }
         var camelize = function(string){
             return string.replace(/-+(.)?/g, function(match, chr) {
               return chr ? chr.toUpperCase() : '';
             });
         };
-        return function(element){
+        var datasetCompat = function(element){
             var sets = {};
             for(var i=0,a=element.attributes,l=a.length;i<l;i++){
                 var attr = a[i];
@@ -1267,6 +1257,14 @@ Namespace('brook.dom.compat')
                 sets[camelize(attr.name.replace(/^data-/,''))] = attr.value;
             }
             return sets;
+        };
+
+        return function(element){
+            var d = element.dataset;
+            if (d && d instanceof DOMStringMap) {
+                return d;
+            }
+            return datasetCompat(element);
         };
     })();
     

--- a/build/brook.js
+++ b/build/brook.js
@@ -289,7 +289,7 @@ Namespace('brook.util')
         return ns.promise(tryLock);
     };
     var from = function(value){
-        if( value.observe ){
+        if( value && value.observe ){
             return ns.promise(function(next,val){
                 value.observe(ns.promise(function(n,v){
                     next(v);
@@ -1244,22 +1244,12 @@ Namespace('brook.view.htmltemplate')
 Namespace('brook.dom.compat')
 .define(function(ns){
     var dataset = (function(){
-        var wrapper = function(element){
-            return element.dataset;
-        };
-        if( 'HTMLElement' in window && HTMLElement.prototype ){
-            var proto = HTMLElement.prototype;
-            if( proto.dataset ) 
-                return wrapper;
-            if( proto.__lookupGetter__ && proto.__lookupGetter__('dataset') ) 
-                return wrapper;
-        }
         var camelize = function(string){
             return string.replace(/-+(.)?/g, function(match, chr) {
               return chr ? chr.toUpperCase() : '';
             });
         };
-        return function(element){
+        var datasetCompat = function(element){
             var sets = {};
             for(var i=0,a=element.attributes,l=a.length;i<l;i++){
                 var attr = a[i];
@@ -1267,6 +1257,14 @@ Namespace('brook.dom.compat')
                 sets[camelize(attr.name.replace(/^data-/,''))] = attr.value;
             }
             return sets;
+        };
+
+        return function(element){
+            var d = element.dataset;
+            if (d && d instanceof DOMStringMap) {
+                return d;
+            }
+            return datasetCompat(element);
         };
     })();
     

--- a/src/brook/dom/compat.js
+++ b/src/brook/dom/compat.js
@@ -12,22 +12,12 @@
 Namespace('brook.dom.compat')
 .define(function(ns){
     var dataset = (function(){
-        var wrapper = function(element){
-            return element.dataset;
-        };
-        if( 'HTMLElement' in window && HTMLElement.prototype ){
-            var proto = HTMLElement.prototype;
-            if( proto.dataset ) 
-                return wrapper;
-            if( proto.__lookupGetter__ && proto.__lookupGetter__('dataset') ) 
-                return wrapper;
-        }
         var camelize = function(string){
             return string.replace(/-+(.)?/g, function(match, chr) {
               return chr ? chr.toUpperCase() : '';
             });
         };
-        return function(element){
+        var datasetCompat = function(element){
             var sets = {};
             for(var i=0,a=element.attributes,l=a.length;i<l;i++){
                 var attr = a[i];
@@ -35,6 +25,14 @@ Namespace('brook.dom.compat')
                 sets[camelize(attr.name.replace(/^data-/,''))] = attr.value;
             }
             return sets;
+        };
+
+        return function(element){
+            var d = element.dataset;
+            if (d && d instanceof DOMStringMap) {
+                return d;
+            }
+            return datasetCompat(element);
         };
     })();
     


### PR DESCRIPTION
brook.dom.compat#datasetの中でdatasetが実装されているかを判断するためにHTMLElement.prototype.datasetにアクセスする処理があるのですが、FFでは該当プロパティにアクセスした時点で「NS_ERROR_XPC_BAD_CONVERT_JS: Could not convert JavaScript argument」というエラーが発生します。

そのため、静的にdatasetプロパティがあるかを判断するのをやめ、動的にelement.datasetにアクセスしてみて仕様に沿った戻り値が得られた場合はその値を使用、そうでない場合は独自実装した関数を呼び出して結果を返却するように変更しました。
